### PR TITLE
Add v2 route for US stocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,36 @@ Go to https://dude-wheres-my-stocks.herokuapp.com/ to see it in action.
 
 ## Endpoints
 
-### /v1/:ticker
+### /v2/:ticker
+
+Returns the current price of company's stock given the company's ticker at one of the stock exchanges in the USA.
+
+#### Request
+
+```
+/v2/:ticker
+```
+
+The `:ticker` should be the symbol of a stock traded at one of stock exchanges in the USA, e.g. `MSFT` or `GE`.
+
+#### Response
+
+```
+{
+  ticker: "MSFT",
+  currentPrice: 210.58
+}
+```
+
+The `ticker` field contains the requested ticker.
+
+The `currentPrice` field contains the current price of the stock in US dollars.
+
+If you pass a non-existent ticker, the service will return currentPrice = 0.
+
+### [DEPRECATED] /v1/:ticker
+
+DEPREACTED: This endpoint does not work correctly since Finnhub stopped offering non-US stocks in free tier. Use `/v2/:ticker` instead to get US stock prices.
 
 Returns the current price of company's stock given the company's ticker at the Warsaw Stock Exchange.
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require("express")
 const v1Router = require("./routes/v1")
+const v2Router = require("./routes/v2")
 const noCache = require("./noCache.js")
 
 const app = express()
@@ -7,5 +8,6 @@ const app = express()
 app.use(noCache)
 
 app.use("/v1", v1Router)
+app.use("/v2", v2Router)
 
 module.exports = app

--- a/src/routes/v2.js
+++ b/src/routes/v2.js
@@ -1,0 +1,25 @@
+const express = require("express")
+const getStockService = require("./../services/stock/getStockService")
+
+const v2Router = express.Router()
+
+v2Router.get("/:ticker", async (req, res, next) => {
+  // Let's pretend the ticker is from NYSE. Finnhub doesn't really care, as long as it is a US stock.
+  exchangeMic = 'XNYS'
+  const ticker = req.params.ticker
+
+  try {
+    const currentPrice = await getStockService().getCurrentStockPrice(exchangeMic, ticker)
+    res.send({
+      ticker,
+      currentPrice
+    })
+  } catch (err) {
+    if (err.status === 429) {
+      return res.sendStatus(err.status)
+    }
+    next(err)
+  }
+})
+
+module.exports = v2Router

--- a/test/e2e/app.spec.js
+++ b/test/e2e/app.spec.js
@@ -3,13 +3,12 @@ const expect = require("chai").expect
 const request = require("supertest")
 
 describe("App", () => {
-  it("/v1/:ticker", async () => {
+  it("/v2/:ticker", async () => {
     await request(app)
-      .get("/v1/CDR")
+      .get("/v2/MSFT")
       .expect(200)
       .then(response => {
-        expect(response.body.exchange).to.equal("XWAR")
-        expect(response.body.ticker).to.equal("CDR")
+        expect(response.body.ticker).to.equal("MSFT")
         expect(response.body.currentPrice).to.be.a("number").that.is.above(0)
       })
   })

--- a/test/unit/app.spec.js
+++ b/test/unit/app.spec.js
@@ -3,27 +3,53 @@ const nock = require("nock")
 const request = require("supertest")
 
 describe("App", () => {
-  it("returns current price for ticker", async () => {
-    const stockPricesMock = createStockPricesMock("08N.WA", 248.8)
+  describe("/v2", () => {
+    it("returns current price for a US ticker", async () => {
+      const stockPricesMock = createStockPricesMock("MSFT", 211.27)
 
-    await request(app)
-      .get("/v1/08N")
-      .expect(200)
-      .expect({
-        exchange: "XWAR",
-        ticker: "08N",
-        currentPrice: 248.8
-      })
+      await request(app)
+        .get("/v2/MSFT")
+        .expect(200)
+        .expect({
+          ticker: "MSFT",
+          currentPrice: 211.27
+        })
 
-    stockPricesMock.done()
+      stockPricesMock.done()
+    })
+
+    it("returns 429 \"Too Many Requests\" when too many requests", async () => {
+      const stockPricesMock = createOverloadedStockPricesMock()
+
+      await request(app)
+        .get("/v2/GE")
+        .expect(429)
+    })
   })
 
-  it("returns 429 \"Too Many Requests\" when too many requests", async () => {
-    const stockPricesMock = createOverloadedStockPricesMock()
+  describe("/v1", () => {
+    it("returns current price for a Warsaw Stock Exchange ticker", async () => {
+      const stockPricesMock = createStockPricesMock("08N.WA", 248.8)
 
-    await request(app)
-      .get("/v1/AB")
-      .expect(429)
+      await request(app)
+        .get("/v1/08N")
+        .expect(200)
+        .expect({
+          exchange: "XWAR",
+          ticker: "08N",
+          currentPrice: 248.8
+        })
+
+      stockPricesMock.done()
+    })
+
+    it("returns 429 \"Too Many Requests\" when too many requests", async () => {
+      const stockPricesMock = createOverloadedStockPricesMock()
+
+      await request(app)
+        .get("/v1/AB")
+        .expect(429)
+    })
   })
 })
 


### PR DESCRIPTION
Since the v1 route offering Polish stock prices stopped working due to Finnhub blocking access to non-US stocks in free tier, let's add a new route for US stocks which should work fine - at least as long as Finnhub allows it.